### PR TITLE
Adding More Data Values to the OHI Data Points and Updating the Included Date

### DIFF
--- a/src/HRQLS/Controllers/Food/Sanitation.php
+++ b/src/HRQLS/Controllers/Food/Sanitation.php
@@ -22,12 +22,12 @@ final class Sanitation
      * @var array
      */
     public $cities = [
-        'norfolk' => 'https://ohi-api.code4hr.org/vendors?after=24-10-2014&city=norfolk',
-        'portsmouth' => 'https://ohi-api.code4hr.org/vendors?after=24-10-2014&city=portsmouth',
-        'virginiabeach' => 'https://ohi-api.code4hr.org/vendors?after=24-10-2014&city=virginia%20beach',
-        'suffolk' => 'https://ohi-api.code4hr.org/vendors?after=24-10-2014&city=suffolk',
-        'hampton' => 'https://ohi-api.code4hr.org/vendors?after=24-10-2014&city=hampton',
-        'chesapeake' => 'https://ohi-api.code4hr.org/vendors?after=24-10-2014&city=chesapeake'
+        'norfolk' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=norfolk',
+        'portsmouth' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=portsmouth',
+        'virginiabeach' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=virginia%20beach',
+        'suffolk' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=suffolk',
+        'hampton' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=hampton',
+        'chesapeake' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=chesapeake'
     ];
 
     /**
@@ -54,6 +54,9 @@ final class Sanitation
                 $data['longitude'] = $toldata['coordinates']['longitude'];
                 $data['city'] = $toldata['city'];
                 $data['score'] = $toldata['score'];
+                $data['address'] = $toldata['address'];
+                $data['type'] = $toldata['type'];
+                $data['category'] = $toldata['category'];
                 $apidata[] = $data['city'];
                     $sanitationdata[] = $data;
             }

--- a/src/HRQLS/Controllers/Food/Sanitation.php
+++ b/src/HRQLS/Controllers/Food/Sanitation.php
@@ -22,12 +22,12 @@ final class Sanitation
      * @var array
      */
     public $cities = [
-        'norfolk' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=norfolk',
-        'portsmouth' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=portsmouth',
-        'virginiabeach' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=virginia%20beach',
-        'suffolk' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=suffolk',
-        'hampton' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=hampton',
-        'chesapeake' => 'https://ohi-api.code4hr.org/vendors?after=01-01-2016&city=chesapeake'
+        'norfolk' => 'https://ohi-api.code4hr.org/vendors?city=norfolk',
+        'portsmouth' => 'https://ohi-api.code4hr.org/vendors?city=portsmouth',
+        'virginiabeach' => 'https://ohi-api.code4hr.org/vendors?city=virginia%20beach',
+        'suffolk' => 'https://ohi-api.code4hr.org/vendors?city=suffolk',
+        'hampton' => 'https://ohi-api.code4hr.org/vendors?city=hampton',
+        'chesapeake' => 'https://ohi-api.code4hr.org/vendors?city=chesapeake'
     ];
 
     /**

--- a/src/HRQLS/Controllers/Food/Sanitation.php
+++ b/src/HRQLS/Controllers/Food/Sanitation.php
@@ -57,6 +57,7 @@ final class Sanitation
                 $data['address'] = $toldata['address'];
                 $data['type'] = $toldata['type'];
                 $data['category'] = $toldata['category'];
+                $data['url'] = $toldata['url'];
                 $apidata[] = $data['city'];
                     $sanitationdata[] = $data;
             }


### PR DESCRIPTION
This PR adds the following values to the OHI Data points: 
* Address
* Type
* Category
* OHI Url

It also updates the date from which to get health inspections. Health inspections will now be retrieved only since the beginning of 2016.